### PR TITLE
Added support for SickStore's Write Concerns

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -68,6 +68,7 @@ DATABASES = {
     "orientdb"     : "com.yahoo.ycsb.db.OrientDBClient",
     "redis"        : "com.yahoo.ycsb.db.RedisClient",
     "tarantool"    : "com.yahoo.ycsb.db.TarantoolClient",
+    "sickstore"    : "com.yahoo.ycsb.db.SickStoreClient",
     "voldemort"    : "com.yahoo.ycsb.db.VoldemortClient"
 }
 

--- a/sickstore/README.md
+++ b/sickstore/README.md
@@ -19,5 +19,7 @@ cd YCSB
  - sickstore.url=localhost => The connection URL.
  - sickstore.port=54000 => 
  - sickstore.timeout=1000 => ...
+ - sickstore.write_concern.ack=1 => The number of acknowledgments from replicas (or a tag set)
+ - sickstore.write_concern.journaling=false => Simulate a journal commit?
 
 ### SickStore

--- a/sickstore/src/main/java/com/yahoo/ycsb/db/SickStoreClient.java
+++ b/sickstore/src/main/java/com/yahoo/ycsb/db/SickStoreClient.java
@@ -224,11 +224,15 @@ public class SickStoreClient extends DB {
             Object value = null;
 
             try {
-                versions = client.scan(table, startkey, recordcount, fields,
-                        true);
+                versions = client.scan(table, startkey, recordcount, fields, true);
             } catch (DatabaseException e) {
                 e.printStackTrace();
                 return STATUS_FAIL;
+            }
+
+            if (fields == null && versions.size() > 0) {
+                // prevent NullPointerException
+                fields = versions.get(0).getValues().keySet();
             }
 
             for (int i = 0; i < versions.size(); i++) {


### PR DESCRIPTION
A write concern that is similar to MongoDB's write concern can be specified for the whole benchmark. Per default, one replica acknowledgment is necessary and a journal commit is not required.